### PR TITLE
chore: add deno 2.x to target in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,14 +22,20 @@ jobs:
         runner:
           - ubuntu-latest
         deno_version:
+          # Minimum Denops support version
           - "1.45.x"
+          # Latest version
+          - "2.x"
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
 
-      - uses: denoland/setup-deno@v1
+      - uses: denoland/setup-deno@v2
         with:
           deno-version: "${{ matrix.deno_version }}"
+
+      - name: Pre-cache dependencies
+        run: deno task cache
 
       - name: Check
         run: deno task check

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -6,6 +6,7 @@
     ]
   },
   "tasks": {
+    "cache": "deno cache **/*.ts",
     "check": "deno lint && deno fmt --check && deno check --no-lock **/*.ts",
     "test": "deno test -A --doc --parallel --shuffle",
     "update": "deno run --unstable-kv --allow-env --allow-read --allow-write --allow-run=git,deno --allow-net=jsr.io,api.jsr.io jsr:@molt/cli@^0.19.1 **/*.ts"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing workflow to run on both the minimum supported and latest Deno versions.
  * Improved workflow efficiency by pre-caching dependencies before running checks.
  * Added explanatory comments to the workflow configuration.
  * Introduced a new task to cache all TypeScript files in the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->